### PR TITLE
Add a special platform name 'unixlike'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Below is an example of `mappings.json`.  You can use `~` to represent a home dir
 
 In addition, you can define platform specific mappings with below mappings JSON files.
 
+- `.dotfiles/mappings_unix.json`: Will link the mappings in Linux or macOS.
 - `.dotfiles/mappings_linux.json`: Will link the mappings in Linux.
 - `.dotfiles/mappings_mac.json`: Will link the mappings in macOS.
 - `.dotfiles/mappings_windows.json`: Will link the mappings in Windows.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Below is an example of `mappings.json`.  You can use `~` to represent a home dir
 
 In addition, you can define platform specific mappings with below mappings JSON files.
 
-- `.dotfiles/mappings_unix.json`: Will link the mappings in Linux or macOS.
+- `.dotfiles/mappings_unixlike.json`: Will link the mappings in Linux or macOS.
 - `.dotfiles/mappings_linux.json`: Will link the mappings in Linux.
 - `.dotfiles/mappings_mac.json`: Will link the mappings in macOS.
 - `.dotfiles/mappings_windows.json`: Will link the mappings in Windows.

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -27,110 +27,73 @@ func (err NothingLinkedError) Error() string {
 type Mappings map[string]abspath.AbsPath
 type MappingsJson map[string]string
 
+var isUnixPlatform = map[string]bool{
+	"linux": true,
+	"darwin": true,
+}
+
 var DefaultMappings = map[string]MappingsJson{
 	"windows": MappingsJson{
 		".gvimrc": "~/vimfiles/gvimrc",
 		".vim":    "~/vimfiles",
 		".vimrc":  "~/vimfiles/vimrc",
 	},
+	"unix": MappingsJson{
+		".agignore":      "~/.agignore",
+		".bash_login":    "~/.bash_login",
+		".bash_profile":  "~/.bash_profile",
+		".bashrc":        "~/.bashrc",
+		".emacs.d":       "~/.emacs.d",
+		".emacs.el":      "~/.emacs.d/init.el",
+		".eslintrc":      "~/.eslintrc",
+		".eslintrc.json": "~/.eslintrc.json",
+		".eslintrc.yml":  "~/.eslintrc.yml",
+		".gvimrc":        "~/.gvimrc",
+		".npmrc":         "~/.npmrc",
+		".profile":       "~/.profile",
+		".pryrc":         "~/.pryrc",
+		".pylintrc":      "~/.pylintrc",
+		".tmux.conf":     "~/.tmux.conf",
+		".vim":           "~/.vim",
+		".vimrc":         "~/.vimrc",
+		".zlogin":        "~/.zlogin",
+		".zprofile":      "~/.zprofile",
+		".zshenv":        "~/.zshenv",
+		".zshrc":         "~/.zshrc",
+		"agignore":       "~/.agignore",
+		"bash_login":     "~/.bash_login",
+		"bash_profile":   "~/.bash_profile",
+		"bashrc":         "~/.bashrc",
+		"emacs.d":        "~/.emacs.d",
+		"emacs.el":       "~/.emacs.d/init.el",
+		"eslintrc":       "~/.eslintrc",
+		"eslintrc.json":  "~/.eslintrc.json",
+		"eslintrc.yml":   "~/.eslintrc.yml",
+		"gvimrc":         "~/.gvimrc",
+		"npmrc":          "~/.npmrc",
+		"profile":        "~/.profile",
+		"pryrc":          "~/.pryrc",
+		"pylintrc":       "~/.pylintrc",
+		"tmux.conf":      "~/.tmux.conf",
+		"vim":            "~/.vim",
+		"vimrc":          "~/.vimrc",
+		"zlogin":         "~/.zlogin",
+		"zprofile":       "~/.zprofile",
+		"zshenv":         "~/.zshenv",
+		"zshrc":          "~/.zshrc",
+		"init.el":        "~/.emacs.d/init.el",
+		"peco":           "~/.config/peco",
+	},
 	"linux": MappingsJson{
 		".Xmodmap":       "~/.Xmodmap",
 		".Xresources":    "~/.Xresources",
-		".agignore":      "~/.agignore",
-		".bash_login":    "~/.bash_login",
-		".bash_profile":  "~/.bash_profile",
-		".bashrc":        "~/.bashrc",
-		".emacs.d":       "~/.emacs.d",
-		".emacs.el":      "~/.emacs.d/init.el",
-		".eslintrc":      "~/.eslintrc",
-		".eslintrc.json": "~/.eslintrc.json",
-		".eslintrc.yml":  "~/.eslintrc.yml",
-		".gvimrc":        "~/.gvimrc",
-		".npmrc":         "~/.npmrc",
-		".profile":       "~/.profile",
-		".pryrc":         "~/.pryrc",
-		".pylintrc":      "~/.pylintrc",
-		".tmux.conf":     "~/.tmux.conf",
-		".vim":           "~/.vim",
-		".vimrc":         "~/.vimrc",
-		".zlogin":        "~/.zlogin",
-		".zprofile":      "~/.zprofile",
-		".zshenv":        "~/.zshenv",
-		".zshrc":         "~/.zshrc",
 		"Xmodmap":        "~/.Xmodmap",
 		"Xresources":     "~/.Xresources",
-		"agignore":       "~/.agignore",
-		"bash_login":     "~/.bash_login",
-		"bash_profile":   "~/.bash_profile",
-		"bashrc":         "~/.bashrc",
-		"emacs.d":        "~/.emacs.d",
-		"emacs.el":       "~/.emacs.d/init.el",
-		"eslintrc":       "~/.eslintrc",
-		"eslintrc.json":  "~/.eslintrc.json",
-		"eslintrc.yml":   "~/.eslintrc.yml",
-		"gvimrc":         "~/.gvimrc",
-		"npmrc":          "~/.npmrc",
-		"profile":        "~/.profile",
-		"pryrc":          "~/.pryrc",
-		"pylintrc":       "~/.pylintrc",
-		"tmux.conf":      "~/.tmux.conf",
-		"vim":            "~/.vim",
-		"vimrc":          "~/.vimrc",
-		"zlogin":         "~/.zlogin",
-		"zprofile":       "~/.zprofile",
-		"zshenv":         "~/.zshenv",
-		"zshrc":          "~/.zshrc",
-		"init.el":        "~/.emacs.d/init.el",
-		"peco":           "~/.config/peco",
 		"rc.lua":         "~/.config/rc.lua",
 	},
 	"darwin": MappingsJson{
-		".agignore":      "~/.agignore",
-		".bash_login":    "~/.bash_login",
-		".bash_profile":  "~/.bash_profile",
-		".bashrc":        "~/.bashrc",
-		".emacs.d":       "~/.emacs.d",
-		".emacs.el":      "~/.emacs.d/init.el",
-		".eslintrc":      "~/.eslintrc",
-		".eslintrc.json": "~/.eslintrc.json",
-		".eslintrc.yml":  "~/.eslintrc.yml",
-		".gvimrc":        "~/.gvimrc",
 		".htoprc":        "~/.htoprc",
-		".npmrc":         "~/.npmrc",
-		".profile":       "~/.profile",
-		".pryrc":         "~/.pryrc",
-		".pylintrc":      "~/.pylintrc",
-		".tmux.conf":     "~/.tmux.conf",
-		".vim":           "~/.vim",
-		".vimrc":         "~/.vimrc",
-		".zlogin":        "~/.zlogin",
-		".zprofile":      "~/.zprofile",
-		".zshenv":        "~/.zshenv",
-		".zshrc":         "~/.zshrc",
-		"agignore":       "~/.agignore",
-		"bash_login":     "~/.bash_login",
-		"bash_profile":   "~/.bash_profile",
-		"bashrc":         "~/.bashrc",
-		"emacs.d":        "~/.emacs.d",
-		"emacs.el":       "~/.emacs.d/init.el",
-		"eslintrc":       "~/.eslintrc",
-		"eslintrc.json":  "~/.eslintrc.json",
-		"eslintrc.yml":   "~/.eslintrc.yml",
-		"gvimrc":         "~/.gvimrc",
 		"htoprc":         "~/.htoprc",
-		"npmrc":          "~/.npmrc",
-		"profile":        "~/.profile",
-		"pryrc":          "~/.pryrc",
-		"pylintrc":       "~/.pylintrc",
-		"tmux.conf":      "~/.tmux.conf",
-		"vim":            "~/.vim",
-		"vimrc":          "~/.vimrc",
-		"zlogin":         "~/.zlogin",
-		"zprofile":       "~/.zprofile",
-		"zshenv":         "~/.zshenv",
-		"zshrc":          "~/.zshrc",
-		"init.el":        "~/.emacs.d/init.el",
-		"peco":           "~/.config/peco",
 	},
 }
 
@@ -176,6 +139,19 @@ func convertMappingsJsonToMappings(json MappingsJson) (Mappings, error) {
 	return m, nil
 }
 
+func mergeMappingsFromDefault(dist *Mappings, platform string) error {
+	m, err := convertMappingsJsonToMappings(DefaultMappings[platform])
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		(*dist)[k] = v
+	}
+
+	return nil
+}
+
 func mergeMappingsFromFile(dist *Mappings, file abspath.AbsPath) error {
 	j, err := parseMappingsJson(file)
 	if err != nil {
@@ -198,18 +174,26 @@ func mergeMappingsFromFile(dist *Mappings, file abspath.AbsPath) error {
 }
 
 func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, error) {
-	m, err := convertMappingsJsonToMappings(DefaultMappings[platform])
-	if err != nil {
-		return nil, err
+	m := Mappings{}
+
+	if isUnixPlatform[platform] {
+		if err := mergeMappingsFromDefault(&m, "unix"); err != nil {
+			return nil, err
+		}
 	}
-	if m == nil {
-		m = Mappings{}
+	if err := mergeMappingsFromDefault(&m, platform); err != nil {
+		return nil, err
 	}
 
 	if err := mergeMappingsFromFile(&m, parent.Join("mappings.json")); err != nil {
 		return nil, err
 	}
 
+	if isUnixPlatform[platform] {
+		if err := mergeMappingsFromFile(&m, parent.Join("mappings_unix.json")); err != nil {
+			return nil, err
+		}
+	}
 	if err := mergeMappingsFromFile(&m, parent.Join(fmt.Sprintf("mappings_%s.json", platform))); err != nil {
 		return nil, err
 	}

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -24,6 +24,9 @@ func (err NothingLinkedError) Error() string {
 	}
 }
 
+// A special platform name used commonly for Unix-like platform
+const PLATFORM_UNIX_LIKE = "unixlike"
+
 type Mappings map[string]abspath.AbsPath
 type MappingsJson map[string]string
 
@@ -33,7 +36,7 @@ var DefaultMappings = map[string]MappingsJson{
 		".vim":    "~/vimfiles",
 		".vimrc":  "~/vimfiles/vimrc",
 	},
-	"unix": MappingsJson{
+	PLATFORM_UNIX_LIKE: MappingsJson{
 		".agignore":      "~/.agignore",
 		".bash_login":    "~/.bash_login",
 		".bash_profile":  "~/.bash_profile",
@@ -176,7 +179,7 @@ func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, 
 	m := Mappings{}
 
 	if isUnixLikePlatform(platform) {
-		if err := mergeMappingsFromDefault(&m, "unix"); err != nil {
+		if err := mergeMappingsFromDefault(&m, PLATFORM_UNIX_LIKE); err != nil {
 			return nil, err
 		}
 	}
@@ -189,7 +192,7 @@ func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, 
 	}
 
 	if isUnixLikePlatform(platform) {
-		if err := mergeMappingsFromFile(&m, parent.Join("mappings_unix.json")); err != nil {
+		if err := mergeMappingsFromFile(&m, parent.Join(fmt.Sprintf("mappings_%s.json", PLATFORM_UNIX_LIKE))); err != nil {
 			return nil, err
 		}
 	}

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -137,20 +137,20 @@ func convertMappingsJsonToMappings(json MappingsJson) (Mappings, error) {
 	return m, nil
 }
 
-func mergeMappingsFromDefault(dist *Mappings, platform string) error {
+func mergeMappingsFromDefault(dist Mappings, platform string) error {
 	m, err := convertMappingsJsonToMappings(DefaultMappings[platform])
 	if err != nil {
 		return err
 	}
 
 	for k, v := range m {
-		(*dist)[k] = v
+		dist[k] = v
 	}
 
 	return nil
 }
 
-func mergeMappingsFromFile(dist *Mappings, file abspath.AbsPath) error {
+func mergeMappingsFromFile(dist Mappings, file abspath.AbsPath) error {
 	j, err := parseMappingsJson(file)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func mergeMappingsFromFile(dist *Mappings, file abspath.AbsPath) error {
 	}
 
 	for k, v := range m {
-		(*dist)[k] = v
+		dist[k] = v
 	}
 
 	return nil
@@ -179,24 +179,24 @@ func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, 
 	m := Mappings{}
 
 	if isUnixLikePlatform(platform) {
-		if err := mergeMappingsFromDefault(&m, PLATFORM_UNIX_LIKE); err != nil {
+		if err := mergeMappingsFromDefault(m, PLATFORM_UNIX_LIKE); err != nil {
 			return nil, err
 		}
 	}
-	if err := mergeMappingsFromDefault(&m, platform); err != nil {
+	if err := mergeMappingsFromDefault(m, platform); err != nil {
 		return nil, err
 	}
 
-	if err := mergeMappingsFromFile(&m, parent.Join("mappings.json")); err != nil {
+	if err := mergeMappingsFromFile(m, parent.Join("mappings.json")); err != nil {
 		return nil, err
 	}
 
 	if isUnixLikePlatform(platform) {
-		if err := mergeMappingsFromFile(&m, parent.Join(fmt.Sprintf("mappings_%s.json", PLATFORM_UNIX_LIKE))); err != nil {
+		if err := mergeMappingsFromFile(m, parent.Join(fmt.Sprintf("mappings_%s.json", PLATFORM_UNIX_LIKE))); err != nil {
 			return nil, err
 		}
 	}
-	if err := mergeMappingsFromFile(&m, parent.Join(fmt.Sprintf("mappings_%s.json", platform))); err != nil {
+	if err := mergeMappingsFromFile(m, parent.Join(fmt.Sprintf("mappings_%s.json", platform))); err != nil {
 		return nil, err
 	}
 

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -27,11 +27,6 @@ func (err NothingLinkedError) Error() string {
 type Mappings map[string]abspath.AbsPath
 type MappingsJson map[string]string
 
-var isUnixPlatform = map[string]bool{
-	"linux": true,
-	"darwin": true,
-}
-
 var DefaultMappings = map[string]MappingsJson{
 	"windows": MappingsJson{
 		".gvimrc": "~/vimfiles/gvimrc",
@@ -173,10 +168,14 @@ func mergeMappingsFromFile(dist *Mappings, file abspath.AbsPath) error {
 	return nil
 }
 
+func isUnixLikePlatform(platform string) bool {
+	return platform == "linux" || platform == "darwin"
+}
+
 func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, error) {
 	m := Mappings{}
 
-	if isUnixPlatform[platform] {
+	if isUnixLikePlatform(platform) {
 		if err := mergeMappingsFromDefault(&m, "unix"); err != nil {
 			return nil, err
 		}
@@ -189,7 +188,7 @@ func GetMappingsForPlatform(platform string, parent abspath.AbsPath) (Mappings, 
 		return nil, err
 	}
 
-	if isUnixPlatform[platform] {
+	if isUnixLikePlatform(platform) {
 		if err := mergeMappingsFromFile(&m, parent.Join("mappings_unix.json")); err != nil {
 			return nil, err
 		}

--- a/src/mappings_test.go
+++ b/src/mappings_test.go
@@ -167,7 +167,7 @@ func TestGetMappingsPlatformSpecificMappingsJson(t *testing.T) {
 }
 
 func TestGetMappingsPlatformSpecificMappingsJsonUnix(t *testing.T) {
-	createTestJson("mappings_unix.json", `
+	createTestJson("mappings_unixlike.json", `
 	{
 		"some_file": "/path/to/some_file",
 		".vimrc": "/hidden/path/vimrc"
@@ -190,7 +190,7 @@ func TestGetMappingsPlatformSpecificMappingsJsonUnix(t *testing.T) {
 		t.Fatal(err)
 	}
 	if m["some_file"].String() != "/path/to/some_file" {
-		t.Errorf("Mapping value set in mappings_unix.json is wrong: '%s' in Darwin", m["some_file"])
+		t.Errorf("Mapping value set in mappings_unixlike.json is wrong: '%s' in Darwin", m["some_file"])
 	}
 	if m[".vimrc"].String() != "/override/path/vimrc" {
 		t.Errorf("Mapping should be overridden by mappings_darwin.json but actually '%s'", m[".vimrc"])


### PR DESCRIPTION
Darwin has derived from Unix and Linux has developed based on (or to mimic) Unix.
So most of dotfiles can be used in both Linux/Darwin and I could not be botherd to keep mappings_linux.json and mappings_darwin.json equal.

This PR add a special platform named 'unixlike'. In Unix-like platform, this special platform name will be used prior to the specific one ('linux' or 'darwin') and the specific one will be used posterior (they override the config for 'unix').

ちなみみこれ、初めて書くGoなのでGoっぽくないところとかあったら突っ込んで頂けると助かります！ :pray: 