### PR TITLE
Fix list command when multiple destinations exist

### DIFF
--- a/src/command_list.go
+++ b/src/command_list.go
@@ -18,8 +18,8 @@ func List(specified string) error {
 		return err
 	}
 
-	for source, dist := range links {
-		fmt.Printf("'%s' -> '%s'\n", source, dist)
+	for _, l := range links {
+		fmt.Printf("'%s' -> '%s'\n", l.src, l.dst)
 	}
 
 	if len(links) == 0 {

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -371,8 +371,8 @@ func (mappings Mappings) UnlinkAll(repo abspath.AbsPath) error {
 	return nil
 }
 
-func (mappings Mappings) ActualLinks(repo abspath.AbsPath) (map[string]string, error) {
-	ret := map[string]string{}
+func (mappings Mappings) ActualLinks(repo abspath.AbsPath) ([]struct{ src, dst string }, error) {
+	ret := make([]struct{ src, dst string }, 0, len(mappings))
 	for _, tos := range mappings {
 		for _, to := range tos {
 			s, err := getLinkSource(repo, to)
@@ -380,7 +380,7 @@ func (mappings Mappings) ActualLinks(repo abspath.AbsPath) (map[string]string, e
 				return nil, err
 			}
 			if s != "" {
-				ret[s] = to.String()
+				ret = append(ret, struct{ src, dst string }{s, to.String()})
 			}
 		}
 	}


### PR DESCRIPTION
I'm sorry but I found a bug in my PR #7 .
`list` command is broken when a mapping like this `"src" -> ["dst1", "dst2"]` exists, because `ActualLinks` function uses `map[string]string`.
I fixed this and added a test case.