### PR TITLE
Fix duplicate links in list command

### DIFF
--- a/src/mappings.go
+++ b/src/mappings.go
@@ -376,7 +376,7 @@ func (maps Mappings) UnlinkAll(repo abspath.AbsPath) error {
 }
 
 func (maps Mappings) ActualLinks(repo abspath.AbsPath) ([]PathLink, error) {
-	m := map[PathLink]bool{}
+	m := map[PathLink]struct{}{}
 	for _, tos := range maps {
 		for _, to := range tos {
 			s, err := getLinkSource(repo, to)
@@ -384,7 +384,7 @@ func (maps Mappings) ActualLinks(repo abspath.AbsPath) ([]PathLink, error) {
 				return nil, err
 			}
 			if s != "" {
-				m[PathLink{s, to.String()}] = true
+				m[PathLink{s, to.String()}] = struct{}{}
 			}
 		}
 	}

--- a/src/mappings.go
+++ b/src/mappings.go
@@ -376,7 +376,7 @@ func (maps Mappings) UnlinkAll(repo abspath.AbsPath) error {
 }
 
 func (maps Mappings) ActualLinks(repo abspath.AbsPath) ([]PathLink, error) {
-	ret := make([]PathLink, 0, len(maps))
+	m := map[PathLink]bool{}
 	for _, tos := range maps {
 		for _, to := range tos {
 			s, err := getLinkSource(repo, to)
@@ -384,9 +384,13 @@ func (maps Mappings) ActualLinks(repo abspath.AbsPath) ([]PathLink, error) {
 				return nil, err
 			}
 			if s != "" {
-				ret = append(ret, PathLink{s, to.String()})
+				m[PathLink{s, to.String()}] = true
 			}
 		}
+	}
+	ret := make([]PathLink, 0, len(m))
+	for l := range m {
+		ret = append(ret, l)
 	}
 	return ret, nil
 }


### PR DESCRIPTION
There was an issue that `list` command can return duplicate results.
It happens when I have a `mappings.json` like this:

```
{
  "my_vimrc": "~/.vimrc"
}
```

Then `Mappings` struct has these two entries:

```
"my_vimrc": "~/.vimrc" // From user's mappings.json
".vimrc":   "~/.vimrc" // From default mappings
```

In `getLinkSource`, it reads symlink (from "~/.vimrc" side) twice, which causes duplicate results like this:

```
'my_vimrc' -> '~/.vimrc'
'my_vimrc' -> '~/.vimrc'
```

I fixed this issue by introducing `map` to remove duplication.